### PR TITLE
Plocate support as an alternative

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Homepage: http://omv-extras.org/
 
 Package: openmediavault-locate
 Architecture: all
-Depends: mlocate,
+Depends: mlocate | plocate,
          openmediavault (>= 6.0.4)
 Description: locate plugin for OpenMediaVault.
  Locate file on system using search term.

--- a/usr/share/openmediavault/engined/rpc/locate.inc
+++ b/usr/share/openmediavault/engined/rpc/locate.inc
@@ -44,7 +44,7 @@ class OMVRpcServiceLocate extends \OMV\Rpc\ServiceAbstract
             $cmdArgs[] = "--ignore-case";
             $cmdArgs[] = "--limit=500";
             $cmdArgs[] = escapeshellarg($params['search']);
-            $cmd = new \OMV\System\Process("mlocate", $cmdArgs);
+            $cmd = new \OMV\System\Process("locate", $cmdArgs);
             $cmd->setQuiet(true);
             $cmd->execute($output);
 


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently, Debian *plocate* is set as `Replace` and `Breaks` *mlocate*.
But since *openmediavault-locate* specify *mlocate* as a `Depends`:

- If *plocate* is already installed, installing the plugin will remove *plocate*.
- If the plugin is installed (with *mlocate*), installing will remove *mlocate* **and** the plugin.

## What is the new behavior?

- The plugin itself is installed with *mlocate* by default (Web UI tested, obviously).
- *plocate* can be installed beforehand, it won't remote it and will use *plocate* in Web UI (tested).
- The plugin can be installed alongside *plocate* (`apt install openmediavault-locate plocate`), it won't trow an error.
- Switching between *mlocate* and *plocate* is possible, but since the config file is the same, *apt* will ask about merging.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

In conclusion, can we say It just works? ( ͡° ͜ʖ ͡°)